### PR TITLE
Mark funtions returning Result as #[must_use]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,7 @@ pub fn add<T: Numeric<T>>(a: &Sprs<T>, b: &Sprs<T>, alpha: T, beta: T) -> Sprs<T
 ///
 /// See: `schol(...)`
 ///
+#[must_use]
 pub fn chol<T: Numeric<T>>(a: &Sprs<T>, s: &mut Symb) -> Result<Nmrc<T>, Error> {
     let mut top;
     let mut d;
@@ -372,6 +373,7 @@ pub fn chol<T: Numeric<T>>(a: &Sprs<T>, s: &mut Symb) -> Result<Nmrc<T>, Error> 
 /// println!("{:?}", &b);
 /// ```
 ///
+#[must_use]
 pub fn cholsol<T: Numeric<T>>(a: &Sprs<T>, b: &mut [T], order: i8) -> Result<(), Error> {
     let n = a.n;
     let mut s = schol(a, order); // ordering and symbolic analysis
@@ -513,6 +515,7 @@ pub fn ltsolve<T: Numeric<T>>(l: &Sprs<T>, x: &mut [T]) {
 ///
 /// See: `sqr(...)`
 ///
+#[must_use]
 pub fn lu<T: Numeric<T>>(a: &Sprs<T>, s: &mut Symb, tol: T) -> Result<Nmrc<T>, Error> {
     let n = a.n;
     let mut col;
@@ -665,6 +668,7 @@ pub fn lu<T: Numeric<T>>(a: &Sprs<T>, s: &mut Symb, tol: T) -> Result<Nmrc<T>, E
 /// ```
 
 ///
+#[must_use]
 pub fn lusol<T: Numeric<T>>(a: &Sprs<T>, b: &mut [T], order: i8, tol: T) -> Result<(), Error> {
     let mut x = vec![T::zero(); a.n];
     let mut s;


### PR DESCRIPTION
Mark functions returning Result as #[must_use], so that if the 'out' variable is not mutated, the program is sure to do something about it. 

I realized that this case might be important if rsparse is used for e.g. robotic control where the output of e.g. `lusol`, stored in `b` here: `lusol(a: &Sprs, b: &mut [T], order: i8, tol: T)` may not have been touched, and could contain an invalid or otherwise dangerous solution. Previously, this would have been avoided by panicking, but now using Result introduces this possibility.